### PR TITLE
Add power management

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ This is a driver for the Mediatek MT7902 PCIe card based on the `gen4-mt79xx` dr
 
 The driver is buildable and loadable. It can be able to connect to 2.4Ghz wifi so far. However, upon testing, I've noticed these issues:
 
-- Lack of power management making sleep broke & on next restart the driver is broken when being loaded. (you have to force shut down using power button to fix this).
 - Can't switch to 5Ghz if you are on a SSID with both 2.4/5.
 - Can't be able to connect to WPA3 networks.
 - Can't create wifi hotspot to act as a repeater.
 - Chunky compiled size with almost ~100mb, might be due to the debug code it has.
 
 > [!WARNING]
-> Because of the first issue, you have to use `sudo rmmod mt7902` whenever you wanna sleep or shut down the device !
+> If the wifi is ever flaky just restart your device and it should kick back on.
 
 There are some features that are untested such as Bluetooth (which is not covered by this driver) and WIFI 6/6E.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Once you got the driver & firmware installed, reboot to see changes.
 
 Currently the driver is being tested on some of these models:
 - WMDM-257AX (tested without antenna connected)
+- AW-XB552NF
 
 ## FAQs
 

--- a/os/linux/hif/pcie/pcie.c
+++ b/os/linux/hif/pcie/pcie.c
@@ -595,7 +595,7 @@ int mtk_pci_resume(struct pci_dev *pdev)
 }
 
 /* Wrap modern dev_pm_ops checks in gaurds and keep the legacy pci suspend and resume setup for backwards compatiblity */
-#if IS_ENABLED(CONFIG_PM)PMSG_SU
+#if IS_ENABLED(CONFIG_PM)
 /* These _pm_ tiny wrappers for the suspend and resume methods have the signature
  * that is expected by the dev_pm_ops
  */


### PR DESCRIPTION
### Purpose
Gracefully handle sleep and reboot in wifi driver.

### Changes
Only the legacy PCI power management hooks for suspend and resume were present
(see here https://github.com/hmtheboy154/gen4-mt7902/blob/25865a88467d146df1b36fdf65b6f557b71b0ae6/os/linux/hif/pcie/pcie.c#L619)

So they seemed to be not getting looked at by my current kernel version (6.14.0-36-generic) during sleep.

This PR creates a dev_pm_pos struct using the SET_SYSTEM_SLEEP_PM_OPS helper method (included in linux/pm.h) in order to set `driver.pm` to that struct so that the kernel ends up calling the sleep hooks that were already in place.
The original mtk_pci_suspend and mtk_pci_resume methods were wrapped so that their signature matches the one expected by dev_pm_pos for the suspend and resume method.

There was also a shutdown hook missing, so that was added and it calls the mtk_pci_suspend to gracefully handle turning down with the already in place logic that was there, in addition to calling remove to finish off the teardown.

The original legacy PCI setting of driver.suspend and driver.resume were left for backwards compatibility, as well as the new changes mostly being wrapped in guards.

### Testing
Locally have been using the module on 6.14.0-36-generic and have been able to let the computer sleep and turn it off and on and the wifi module boot up and run behind the scenes without manual intervention of loading and unloading the module.