### PR TITLE
Handle deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ This is a driver for the Mediatek MT7902 PCIe card based on the `gen4-mt79xx` dr
 
 The driver is buildable and loadable. It can be able to connect to 2.4Ghz wifi so far. However, upon testing, I've noticed these issues:
 
-- Lack of power management making sleep broke & on next restart the driver is broken when being loaded. (you have to force shut down using power button to fix this).
 - Can't switch to 5Ghz if you are on a SSID with both 2.4/5.
 - Can't be able to connect to WPA3 networks.
 - Can't create wifi hotspot to act as a repeater.
 - Chunky compiled size with almost ~100mb, might be due to the debug code it has.
 
 > [!WARNING]
-> Because of the first issue, you have to use `sudo rmmod mt7902` whenever you wanna sleep or shut down the device !
+> If the wifi is ever flaky just restart your device and it should kick back on.
 
 There are some features that are untested such as Bluetooth (which is not covered by this driver) and WIFI 6/6E.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Once you got the driver & firmware installed, reboot to see changes.
 
 Currently the driver is being tested on some of these models:
 - WMDM-257AX (tested without antenna connected)
+- AW-XB552NF
 
 ## FAQs
 

--- a/os/linux/gl_p2p_kal.c
+++ b/os/linux/gl_p2p_kal.c
@@ -212,7 +212,7 @@ kalP2PUpdateAssocInfo(IN struct GLUE_INFO *prGlueInfo,
 			[prBssInfo->u4PrivateData]->aprRoleHandler;
 
 	/* Send event to user space */
-	wireless_send_event(prNetdevice, IWEVASSOCREQIE, &wrqu, pucExtraInfo);
+	kalWirelessEventSend(prNetdevice, IWEVASSOCREQIE, &wrqu, pucExtraInfo);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -249,7 +249,7 @@ kalP2PSetState(IN struct GLUE_INFO *prGlueInfo,
 		evt.data.length = strlen(aucBuffer);
 
 		/* indicate in IWECUSTOM event */
-		wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+		kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 			IWEVCUSTOM, &evt, aucBuffer);
 
 	} else if (eState == MEDIA_STATE_DISCONNECTED) {
@@ -258,7 +258,7 @@ kalP2PSetState(IN struct GLUE_INFO *prGlueInfo,
 		evt.data.length = strlen(aucBuffer);
 
 		/* indicate in IWECUSTOM event */
-		wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+		kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 			IWEVCUSTOM, &evt, aucBuffer);
 	} else {
 		ASSERT(0);
@@ -365,7 +365,7 @@ kalP2PSetRole(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate in IWECUSTOM event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* end of kalP2PSetRole() */
@@ -699,7 +699,7 @@ void kalP2PIndicateConnReq(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate in IWEVCUSTOM event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* end of kalP2PIndicateConnReq() */
@@ -753,7 +753,7 @@ kalP2PInvitationIndication(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate in IWEVCUSTOM event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 #else
@@ -863,7 +863,7 @@ void kalP2PInvitationStatus(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate in IWEVCUSTOM event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* kalP2PInvitationStatus */
@@ -901,7 +901,7 @@ void kalP2PIndicateSDRequest(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate IWEVP2PSDREQ event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* end of kalP2PIndicateSDRequest() */
@@ -937,7 +937,7 @@ void kalP2PIndicateSDResponse(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate IWEVP2PSDREQ event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* end of kalP2PIndicateSDResponse() */
@@ -975,7 +975,7 @@ void kalP2PIndicateTXDone(IN struct GLUE_INFO *prGlueInfo,
 	evt.data.length = strlen(aucBuffer);
 
 	/* indicate IWEVP2PSDREQ event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 
 }				/* end of kalP2PIndicateSDResponse() */
@@ -1017,7 +1017,7 @@ void kalP2PIndicateSecCheckRsp(IN struct GLUE_INFO *prGlueInfo,
 		prGlueInfo->prP2PInfo[0]->aucSecCheckRsp, u2RspLen);
 #endif
 	/* indicate in IWECUSTOM event */
-	wireless_send_event(prGlueInfo->prP2PInfo[0]->prDevHandler,
+	kalWirelessEventSend(prGlueInfo->prP2PInfo[0]->prDevHandler,
 		IWEVCUSTOM, &evt, aucBuffer);
 }				/* p2pFsmRunEventRxDisassociation */
 #endif

--- a/os/linux/gl_wext.c
+++ b/os/linux/gl_wext.c
@@ -4459,7 +4459,7 @@ wext_support_ioctl_SIOCSIWPMKSA_Action(IN struct net_device
  * \return (none)
  *
  * \note Event is indicated to upper layer if cmd is supported and data is
- *	 valid. Using of kernel symbol wireless_send_event(), which is defined
+ *	 valid. Using of kernel symbol kalWirelessEventSend(), which is defined
  *	 in <net/iw_handler.h> after WE-14 (2.4.20).
  */
 /*----------------------------------------------------------------------------*/
@@ -4644,10 +4644,8 @@ wext_indicate_wext_event(IN struct GLUE_INFO *prGlueInfo,
 	}
 
 	/* Send event to user space */
-	if (prGlueInfo->u4ReadyFlag != 0) {
-		wireless_send_event(prDevHandler, u4Cmd, &wrqu,
- 			    pucExtraInfo);
-	}
+	kalWirelessEventSend(prDevHandler, u4Cmd, &wrqu,
+			    pucExtraInfo);
 
 skip_indicate_event:
 	return;

--- a/os/linux/hif/pcie/pcie.c
+++ b/os/linux/hif/pcie/pcie.c
@@ -595,7 +595,7 @@ int mtk_pci_resume(struct pci_dev *pdev)
 }
 
 /* Wrap modern dev_pm_ops checks in gaurds and keep the legacy pci suspend and resume setup for backwards compatiblity */
-#if IS_ENABLED(CONFIG_PM)PMSG_SU
+#if IS_ENABLED(CONFIG_PM)
 /* These _pm_ tiny wrappers for the suspend and resume methods have the signature
  * that is expected by the dev_pm_ops
  */

--- a/os/linux/include/gl_wext.h
+++ b/os/linux/include/gl_wext.h
@@ -63,6 +63,16 @@
 #define _GL_WEXT_H
 
 #ifdef WIRELESS_EXT
+#include <linux/kconfig.h>
+
+/* Skip wireless extension events when the kernel is built without WEXT */
+#if IS_REACHABLE(CONFIG_WEXT_CORE)
+#define kalWirelessEventSend(dev, cmd, wrqu, extra) \
+	wireless_send_event(dev, cmd, wrqu, extra)
+#else
+#define kalWirelessEventSend(dev, cmd, wrqu, extra) \
+	do { } while (0)
+#endif
 /*******************************************************************************
  *                         C O M P I L E R   F L A G S
  *******************************************************************************


### PR DESCRIPTION
### Purpose
On the current latest upgrade kernel in Fedora at the moment 6.17.9... I got this error when compiling
```
ERROR: modpost: "wireless_send_event" [mt7902.ko] undefined!
```
because Fedora turned off `CONFIG_CFG80211_WEXT`.

This PR resolves that.

### Changes
Replaced the `wireless_send_event` calls with a new stubbed method `kalWirelessEventSend` to handle when wireless_send_event isn't defined. 

(Note: This is branched off of the AddPowerManagement branch, so when that merges it will reduce the changes to a single commit)

### Testing
Was able to build, install, and run the mt7902 module on Fedora with latest upgrade now