### PR TITLE
build: auto-detect clang/LLVM toolchain from kernel config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,35 @@ ccflags-y += -DWLAN_INCLUDE_PROC
 ccflags-y += -DCFG_SUPPORT_AGPS_ASSIST=0
 ccflags-y += -DCFG_SUPPORT_TSF_USING_BOOTTIME=1
 ccflags-y += -DARP_MONITER_ENABLE=1
-ccflags-y += -Werror -Wno-incompatible-function-pointer-types
-ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations -Wno-attribute-warning -Wno-empty-body
+
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_BUILD_DIR := /lib/modules/$(KVER)/build
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(KERNEL_BUILD_DIR)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    # Clang/LLVM toolchain
+    CC := clang
+    HOSTCC := clang
+    LLVM := 1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+    ccflags-y += -Wno-unknown-warning-option
+    ccflags-y += -Wno-incompatible-function-pointer-types
+    ccflags-y += -Wno-array-bounds
+else
+    # GCC toolchain
+    $(info Building with GCC)
+    # GCC 12+ has stricter array bounds checking
+    GCC_VER_GE12 := $(shell expr `$(CC) -dumpversion | cut -d. -f1` \>= 12 2>/dev/null || echo 0)
+    ifeq ($(GCC_VER_GE12),1)
+        ccflags-y += -Wno-array-bounds
+    endif
+endif
+
+# Common warning suppressions (both compilers)
+ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations
+ccflags-y += -Wno-attribute-warning -Wno-empty-body
 #ccflags-y:=$(filter-out -U$(WLAN_CHIP_ID),$(ccflags-y))
 #ccflags-y += -DLINUX -D$(WLAN_CHIP_ID)
 #workaround: also needed for none LINUX system

--- a/Makefile.x86
+++ b/Makefile.x86
@@ -19,6 +19,20 @@ export MTK_COMBO_CHIP=MT7902
 PWD=$(shell pwd)
 DRIVER_DIR=$(PWD)
 
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(LINUX_SRC)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    CC := clang
+    HOSTCC := clang
+    LLVM_FLAGS := LLVM=1 LLVM_IAS=1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+else
+    LLVM_FLAGS :=
+endif
+
 #Handle the compression option for modules in 3.18+
 ifneq ("","$(wildcard $(MT76DIR)/*.ko.gz)")
 COMPRESS_GZIP := y
@@ -261,15 +275,11 @@ endif
 endif
 
 driver:
-	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-
-# driver:
-#	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-#	@cd $(DRIVER_DIR) && cp $(MODULES_NAME)_$(hif).ko $(MODULES_NAME).ko
+	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
 
 clean: driver_clean
 
 driver_clean:
-	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) clean
+	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) clean
 
 .PHONY: all clean driver driver_clean


### PR DESCRIPTION
## Summary

Fixes #19

Auto-detect if the kernel was built with clang by checking `CONFIG_CC_IS_CLANG` in the kernel's `autoconf.h`. This ensures the driver is built with the same compiler toolchain as the kernel, which is required for ABI compatibility.

## Changes

- Add compiler detection to `Makefile` and `Makefile.x86`
- Set `CC=clang` and `LLVM=1` flags when clang-built kernel detected
- Apply compiler-specific warning suppressions (clang vs GCC)
- Use `LLVM_FLAGS` variable in `Makefile.x86` to reduce duplication

## Testing

- Tested on CachyOS with clang-built `6.18.8-3-cachyos` kernel
- Module builds and loads successfully
- WiFi connects to 2.4GHz and 5GHz networks