### PR TITLE
fix: use C99 flexible array member in SUB_ELEMENT to fix FORTIFY_SOURCE warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,35 @@ ccflags-y += -DWLAN_INCLUDE_PROC
 ccflags-y += -DCFG_SUPPORT_AGPS_ASSIST=0
 ccflags-y += -DCFG_SUPPORT_TSF_USING_BOOTTIME=1
 ccflags-y += -DARP_MONITER_ENABLE=1
-ccflags-y += -Werror -Wno-incompatible-function-pointer-types
-ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations -Wno-attribute-warning -Wno-empty-body
+
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_BUILD_DIR := /lib/modules/$(KVER)/build
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(KERNEL_BUILD_DIR)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    # Clang/LLVM toolchain
+    CC := clang
+    HOSTCC := clang
+    LLVM := 1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+    ccflags-y += -Wno-unknown-warning-option
+    ccflags-y += -Wno-incompatible-function-pointer-types
+    ccflags-y += -Wno-array-bounds
+else
+    # GCC toolchain
+    $(info Building with GCC)
+    # GCC 12+ has stricter array bounds checking
+    GCC_VER_GE12 := $(shell expr `$(CC) -dumpversion | cut -d. -f1` \>= 12 2>/dev/null || echo 0)
+    ifeq ($(GCC_VER_GE12),1)
+        ccflags-y += -Wno-array-bounds
+    endif
+endif
+
+# Common warning suppressions (both compilers)
+ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations
+ccflags-y += -Wno-attribute-warning -Wno-empty-body
 #ccflags-y:=$(filter-out -U$(WLAN_CHIP_ID),$(ccflags-y))
 #ccflags-y += -DLINUX -D$(WLAN_CHIP_ID)
 #workaround: also needed for none LINUX system

--- a/Makefile.x86
+++ b/Makefile.x86
@@ -19,6 +19,20 @@ export MTK_COMBO_CHIP=MT7902
 PWD=$(shell pwd)
 DRIVER_DIR=$(PWD)
 
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(LINUX_SRC)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    CC := clang
+    HOSTCC := clang
+    LLVM_FLAGS := LLVM=1 LLVM_IAS=1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+else
+    LLVM_FLAGS :=
+endif
+
 #Handle the compression option for modules in 3.18+
 ifneq ("","$(wildcard $(MT76DIR)/*.ko.gz)")
 COMPRESS_GZIP := y
@@ -261,15 +275,11 @@ endif
 endif
 
 driver:
-	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-
-# driver:
-#	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-#	@cd $(DRIVER_DIR) && cp $(MODULES_NAME)_$(hif).ko $(MODULES_NAME).ko
+	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
 
 clean: driver_clean
 
 driver_clean:
-	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) clean
+	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) clean
 
 .PHONY: all clean driver driver_clean

--- a/include/nic/mac.h
+++ b/include/nic/mac.h
@@ -2477,7 +2477,7 @@ struct ACTION_NEIGHBOR_REPORT_FRAME {
 struct SUB_ELEMENT {
 	uint8_t ucSubID;
 	uint8_t ucLength;
-	uint8_t aucOptInfo[1];
+	uint8_t aucOptInfo[];  /* C99 flexible array member */
 } __KAL_ATTRIB_PACKED__;
 
 struct SM_BASIC_REQ {

--- a/mgmt/ais_fsm.c
+++ b/mgmt/ais_fsm.c
@@ -6904,7 +6904,7 @@ void aisSendNeighborRequest(struct ADAPTER *prAdapter,
 	uint8_t ucBssIndex)
 {
 	struct SUB_ELEMENT_LIST *prSSIDIE;
-	uint8_t aucBuffer[sizeof(*prSSIDIE) + 31];
+	uint8_t aucBuffer[sizeof(*prSSIDIE) + ELEM_MAX_LEN_SSID];
 	struct BSS_INFO *prBssInfo
 		= aisGetAisBssInfo(prAdapter, ucBssIndex);
 


### PR DESCRIPTION
## Summary

Fixes #21

The kernel's `CONFIG_FORTIFY_SOURCE` detects a buffer overflow when copying SSIDs into the `aucOptInfo` field because it was declared as a 1-byte array (old-style flexible array pattern) but used to store up to 32 bytes.

## Error Fixed

```
memcpy: detected field-spanning write (size 13) of single field 
"&prSSIDIE->rSubIE.aucOptInfo[0]" at mgmt/ais_fsm.c:6915 (size 1)
WARNING: CPU: 14 PID: 845 at mgmt/ais_fsm.c:6915 aisSendNeighborRequest+0x140/0x150 [mt7902]
```

## Changes

- `include/nic/mac.h`: Change `aucOptInfo[1]` to `aucOptInfo[]` (C99 flexible array member)
- `mgmt/ais_fsm.c`: Change buffer size from `+31` to `+ELEM_MAX_LEN_SSID` to maintain correct 32-byte SSID capacity

## Analysis

| Location | Before | After |
|----------|--------|-------|
| `sizeof(SUB_ELEMENT)` | 3 bytes | 2 bytes |
| `ais_fsm.c` buffer | 48 bytes (32 for SSID) | 48 bytes (32 for SSID) |
| `wlan_oid.c` alloc | 1 byte over | Exact |

The fix maintains the same buffer capacity while eliminating the FORTIFY_SOURCE warning.

## Testing

- Build: Passes with clang (CachyOS 6.18.8-3-cachyos)
- Static analysis: `sparse` reports no warnings on changed lines
- Audit: All usages of `SUB_ELEMENT` and `aucOptInfo` verified

## Related

- #22 - NULL pointer bug discovered in same investigation (separate fix needed)
- #15 - Related ASUS hardware stability issues

## Note

This PR is based on #20 (clang build fix) which is required to build on clang-based kernels.