### PR TITLE
Incease the size of max_channel_count to not wrap.

### DIFF
--- a/mgmt/rlm_domain.c
+++ b/mgmt/rlm_domain.c
@@ -1409,7 +1409,7 @@ static void rlmSetEd_EU(struct ADAPTER *prAdapter, uint32_t u4CountryCode)
 void rlmDomainSendDomainInfoCmd_V2(struct ADAPTER *prAdapter)
 {
 #if (CFG_SUPPORT_SINGLE_SKU == 1)
-	u8 max_channel_count = 0;
+	u32 max_channel_count = 0;
 	u32 buff_max_size, buff_valid_size;
 	struct CMD_SET_DOMAIN_INFO_V2 *prCmd;
 	struct CMD_DOMAIN_ACTIVE_CHANNEL_LIST *prChs;


### PR DESCRIPTION
The variable `max_channel_count` in the function `rlmDomainSendDomainInfoCmd_V2` is a u8 (8-bit unsigned integer). This variable is  used to calculate the total number of channels across the 2.4GHz, 5GHz, and 6GHz bands. The total number of channels frequently exceeds 255, which is the maximum value a u8 can hold. This caused an integer overflow, leading to the allocation of a much smaller memory buffer than required. When the system tried to write the full channel list into this undersized
buffer, it resulted in a buffer overflow, corrupting kernel memory and causing the panic.

This is u32 in other places max_channel_count is used, its likely just a human error in the original declaration.

I have changed the type of the max_channel_count variable from u8 to u32 (32-bit unsigned integer).

This provides space for the channel count, preventing the overflow and ensuring that a memory buffer of the correct size is allocated.

I have not validated that this is an exploitable bug.  I know it at least reads from out of bounds memory outside the page, its likely that an attacker can abuse this.