### PR TITLE
fix: driver stability improvements and NULL pointer crash fix

### DIFF
--- a/common/wlan_lib.c
+++ b/common/wlan_lib.c
@@ -4583,7 +4583,18 @@ uint32_t wlanQueryNicCapability(IN struct ADAPTER
 			NULL, FALSE, 0, S2D_INDEX_CMD_H2N,
 			prCmdInfo->fgNeedResp);
 
-	wlanSendCommand(prAdapter, prCmdInfo);
+	{
+		uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+		if (rStatus != WLAN_STATUS_SUCCESS &&
+		    rStatus != WLAN_STATUS_PENDING) {
+			DBGLOG(INIT, WARN, "%s: send command failed! status=%u\n",
+			       __func__, rStatus);
+			cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+			kalMemFree(aucBuffer, PHY_MEM_TYPE, u4EventSize);
+			return WLAN_STATUS_FAILURE;
+		}
+	}
 
 	cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 
@@ -4777,7 +4788,18 @@ uint32_t wlanQueryPdMcr(IN struct ADAPTER *prAdapter,
 	kalMemCopy(prCmdMcrQuery, prMcrRdInfo,
 		   sizeof(struct CMD_ACCESS_REG));
 
-	wlanSendCommand(prAdapter, prCmdInfo);
+	{
+		uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+		if (rStatus != WLAN_STATUS_SUCCESS &&
+		    rStatus != WLAN_STATUS_PENDING) {
+			DBGLOG(INIT, WARN, "%s: send command failed! status=%u\n",
+			       __func__, rStatus);
+			cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+			kalMemFree(aucBuffer, PHY_MEM_TYPE, u4EventSize);
+			return WLAN_STATUS_FAILURE;
+		}
+	}
 	cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 #else
 	wlanSendSetQueryCmdHelper(
@@ -6533,7 +6555,18 @@ uint32_t wlanQueryNicCapabilityV2(IN struct ADAPTER *prAdapter)
 			NULL, FALSE, 0, S2D_INDEX_CMD_H2N,
 			prCmdInfo->fgNeedResp);
 
-		wlanSendCommand(prAdapter, prCmdInfo);
+		{
+			uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+			if (rStatus != WLAN_STATUS_SUCCESS &&
+			    rStatus != WLAN_STATUS_PENDING) {
+				DBGLOG(INIT, WARN,
+				       "%s: send command failed! status=%u\n",
+				       __func__, rStatus);
+				cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+				return WLAN_STATUS_FAILURE;
+			}
+		}
 
 		cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 

--- a/common/wlan_lib.c
+++ b/common/wlan_lib.c
@@ -4746,6 +4746,10 @@ uint32_t wlanQueryPdMcr(IN struct ADAPTER *prAdapter,
 	u4EventSize = prChipInfo->rxd_size + prChipInfo->event_hdr_size +
 		struct CMD_ACCESS_REG;
 	aucBuffer = kalMemAlloc(u4EventSize, PHY_MEM_TYPE);
+	if (!aucBuffer) {
+		DBGLOG(INIT, ERROR, "Not enough memory for aucBuffer\n");
+		return WLAN_STATUS_FAILURE;
+	}
 
 #ifndef CFG_SUPPORT_UNIFIED_COMMAND
 	/* compose CMD_BUILD_CONNECTION cmd pkt */

--- a/common/wlan_lib.c
+++ b/common/wlan_lib.c
@@ -1155,18 +1155,22 @@ uint32_t wlanAdapterStart(IN struct ADAPTER *prAdapter,
 
 		wlanOnPostNicInitAdapter(prAdapter, prRegInfo, bAtResetFlow);
 
-		u4Status = wlanWakeUpWiFi(prAdapter);
-		if (u4Status != WLAN_STATUS_SUCCESS) {
-			DBGLOG(INIT, ERROR, "wlanWakeUpWiFi failed!\n");
-			u4Status = WLAN_STATUS_FAILURE;
-			break;
-		}
-
-		/* 4 <5> HIF SW info initialize */
+		/* 4 <5> HIF SW info initialize
+		 * Must be called before wlanWakeUpWiFi() because if WiFi hardware
+		 * is already ON, wlanWakeUpWiFi() attempts to power it off first,
+		 * which requires sending commands via the TX DMA rings.
+		 */
 		if (!halHifSwInfoInit(prAdapter)) {
 			DBGLOG(INIT, ERROR, "halHifSwInfoInit failed!\n");
 			u4Status = WLAN_STATUS_FAILURE;
 			eFailReason = INIT_HIFINFO_FAIL;
+			break;
+		}
+
+		u4Status = wlanWakeUpWiFi(prAdapter);
+		if (u4Status != WLAN_STATUS_SUCCESS) {
+			DBGLOG(INIT, ERROR, "wlanWakeUpWiFi failed!\n");
+			u4Status = WLAN_STATUS_FAILURE;
 			break;
 		}
 

--- a/include/nic/mac.h
+++ b/include/nic/mac.h
@@ -2477,7 +2477,7 @@ struct ACTION_NEIGHBOR_REPORT_FRAME {
 struct SUB_ELEMENT {
 	uint8_t ucSubID;
 	uint8_t ucLength;
-	uint8_t aucOptInfo[1];
+	uint8_t aucOptInfo[];
 } __KAL_ATTRIB_PACKED__;
 
 struct SM_BASIC_REQ {

--- a/mgmt/ais_fsm.c
+++ b/mgmt/ais_fsm.c
@@ -6904,7 +6904,7 @@ void aisSendNeighborRequest(struct ADAPTER *prAdapter,
 	uint8_t ucBssIndex)
 {
 	struct SUB_ELEMENT_LIST *prSSIDIE;
-	uint8_t aucBuffer[sizeof(*prSSIDIE) + 31];
+	uint8_t aucBuffer[sizeof(*prSSIDIE) + ELEM_MAX_LEN_SSID];
 	struct BSS_INFO *prBssInfo
 		= aisGetAisBssInfo(prAdapter, ucBssIndex);
 

--- a/mgmt/p2p_func.c
+++ b/mgmt/p2p_func.c
@@ -3767,7 +3767,7 @@ void p2pFuncValidateRxActionFrame(IN struct ADAPTER *prAdapter,
 					prActPubVenFrame->ucPubSubType,
 					&fgBufferFrame);
 		}
-		/* Fall through */
+		fallthrough;
 	default:
 		break;
 	}

--- a/os/linux/gl_kal.c
+++ b/os/linux/gl_kal.c
@@ -6944,6 +6944,7 @@ static void kalProcessCfg80211RxPkt(struct PARAM_CFG80211_REQ *prCfg80211Req)
 #if (KERNEL_VERSION(5, 1, 0) <= CFG80211_VERSION_CODE)
 		/* [TODO] Set uapsd_queues/req_ies/req_ies_len properly */
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	{
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 		struct cfg80211_rx_assoc_resp_data resp = {
 #else
@@ -6958,6 +6959,7 @@ static void kalProcessCfg80211RxPkt(struct PARAM_CFG80211_REQ *prCfg80211Req)
 		resp.req_ies_len = 0;
 		resp.uapsd_queues = 0;
 		cfg80211_rx_assoc_resp(prCfg80211Req->prDevHandler, &resp);
+	}
 #else
 		cfg80211_rx_assoc_resp(prCfg80211Req->prDevHandler,
 			prCfg80211Req->bss,


### PR DESCRIPTION
## Summary

Three stability fixes for the mt7902 driver, primarily addressing a NULL pointer dereference crash during driver initialization.

## Changes

### 1. fix: stability improvements and compiler warning fixes
- Add NULL check for `aucBuffer` allocation in `wlanQueryPdMcr()`
- Use C99 flexible array member (`aucOptInfo[]`) in `struct SUB_ELEMENT` instead of `aucOptInfo[1]`
- Replace magic number `31` with `ELEM_MAX_LEN_SSID` in `aisSendNeighborRequest()`
- Use `fallthrough` keyword instead of `/* Fall through */` comment
- Fix missing braces in `gl_kal.c` for kernel 6.1+ `cfg80211_rx_assoc_resp` block

### 2. fix: check wlanSendCommand return value before waiting for response
Three call sites (`wlanQueryNicCapability`, `wlanQueryPdMcr`, `wlanQueryNicCapabilityV2`) were ignoring the return value of `wlanSendCommand()`. If the send fails, the code would proceed to wait for a response that never arrives. Now checks the return value and bails out with proper resource cleanup on failure.

### 3. fix: reorder HIF init before WiFi wake-up to prevent NULL pointer crash
When WiFi hardware is already powered on during driver initialization (e.g., after a system crash or when firmware persists across reboots), `wlanWakeUpWiFi()` calls `wlanPowerOffWifi()` to cleanly reset the hardware. However, this sends commands through the TX DMA rings, which are not allocated until `halHifSwInfoInit()` runs.

The original initialization order in `wlanAdapterStart()` was:
1. `wlanWakeUpWiFi()` — may call `wlanPowerOffWifi()` if WiFi is ON
2. `halHifSwInfoInit()` — allocates TX DMA rings

This caused a NULL pointer dereference in `halWpdmaWriteCmd()` when accessing uninitialized TX rings:

```
BUG: kernel NULL pointer dereference, address: 0000000000000000
RIP: 0010:halWpdmaWriteCmd+0x16b/0x2d0 [mt7902]
Call Trace:
  kalDevWriteCmd+0xa2
  nicTxCmd+0x1af
  wlanSendNicPowerCtrlCmd+0x198
  halHifPowerOffWifi+0x57
  wlanAdapterStart+0x1b9
  wlanProbe+0xb71
  mtk_pci_probe+0x8b
```

This crash has been confirmed on multiple systems and kernel versions:
- CachyOS with kernel 6.18.8-3-cachyos (ASUS B760M)
- LTS kernel 6.12.68-2-lts (Gigabyte B1400FN)

Fix: reorder so `halHifSwInfoInit()` is called before `wlanWakeUpWiFi()`, ensuring TX DMA rings are always available before any code attempts to send commands.

Fixes #22