### PR TITLE
fix: stability improvements and wlanSendCommand error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,35 @@ ccflags-y += -DWLAN_INCLUDE_PROC
 ccflags-y += -DCFG_SUPPORT_AGPS_ASSIST=0
 ccflags-y += -DCFG_SUPPORT_TSF_USING_BOOTTIME=1
 ccflags-y += -DARP_MONITER_ENABLE=1
-ccflags-y += -Werror -Wno-incompatible-function-pointer-types
-ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations -Wno-attribute-warning -Wno-empty-body
+
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_BUILD_DIR := /lib/modules/$(KVER)/build
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(KERNEL_BUILD_DIR)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    # Clang/LLVM toolchain
+    CC := clang
+    HOSTCC := clang
+    LLVM := 1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+    ccflags-y += -Wno-unknown-warning-option
+    ccflags-y += -Wno-incompatible-function-pointer-types
+    ccflags-y += -Wno-array-bounds
+else
+    # GCC toolchain
+    $(info Building with GCC)
+    # GCC 12+ has stricter array bounds checking
+    GCC_VER_GE12 := $(shell expr `$(CC) -dumpversion | cut -d. -f1` \>= 12 2>/dev/null || echo 0)
+    ifeq ($(GCC_VER_GE12),1)
+        ccflags-y += -Wno-array-bounds
+    endif
+endif
+
+# Common warning suppressions (both compilers)
+ccflags-y += -Wno-missing-prototypes -Wno-missing-declarations
+ccflags-y += -Wno-attribute-warning -Wno-empty-body
 #ccflags-y:=$(filter-out -U$(WLAN_CHIP_ID),$(ccflags-y))
 #ccflags-y += -DLINUX -D$(WLAN_CHIP_ID)
 #workaround: also needed for none LINUX system

--- a/Makefile.x86
+++ b/Makefile.x86
@@ -19,6 +19,20 @@ export MTK_COMBO_CHIP=MT7902
 PWD=$(shell pwd)
 DRIVER_DIR=$(PWD)
 
+# ---------------------------------------------------
+# Compiler Detection - match kernel's compiler
+# ---------------------------------------------------
+KERNEL_IS_CLANG := $(shell grep -qs 'CONFIG_CC_IS_CLANG' $(LINUX_SRC)/include/generated/autoconf.h && echo 1 || echo 0)
+
+ifeq ($(KERNEL_IS_CLANG),1)
+    CC := clang
+    HOSTCC := clang
+    LLVM_FLAGS := LLVM=1 LLVM_IAS=1
+    $(info Building with clang (kernel built with CONFIG_CC_IS_CLANG))
+else
+    LLVM_FLAGS :=
+endif
+
 #Handle the compression option for modules in 3.18+
 ifneq ("","$(wildcard $(MT76DIR)/*.ko.gz)")
 COMPRESS_GZIP := y
@@ -261,15 +275,11 @@ endif
 endif
 
 driver:
-	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-
-# driver:
-#	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
-#	@cd $(DRIVER_DIR) && cp $(MODULES_NAME)_$(hif).ko $(MODULES_NAME).ko
+	+cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) PLATFORM_FLAGS="$(PLATFORM_FLAGS)" modules
 
 clean: driver_clean
 
 driver_clean:
-	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) clean
+	cd $(DRIVER_DIR) && make -C $(LINUX_SRC) M=$(DRIVER_DIR) $(LLVM_FLAGS) clean
 
 .PHONY: all clean driver driver_clean

--- a/common/wlan_lib.c
+++ b/common/wlan_lib.c
@@ -4583,7 +4583,18 @@ uint32_t wlanQueryNicCapability(IN struct ADAPTER
 			NULL, FALSE, 0, S2D_INDEX_CMD_H2N,
 			prCmdInfo->fgNeedResp);
 
-	wlanSendCommand(prAdapter, prCmdInfo);
+	{
+		uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+		if (rStatus != WLAN_STATUS_SUCCESS &&
+		    rStatus != WLAN_STATUS_PENDING) {
+			DBGLOG(INIT, WARN, "%s: send command failed! status=%u\n",
+			       __func__, rStatus);
+			cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+			kalMemFree(aucBuffer, PHY_MEM_TYPE, u4EventSize);
+			return WLAN_STATUS_FAILURE;
+		}
+	}
 
 	cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 
@@ -4777,7 +4788,18 @@ uint32_t wlanQueryPdMcr(IN struct ADAPTER *prAdapter,
 	kalMemCopy(prCmdMcrQuery, prMcrRdInfo,
 		   sizeof(struct CMD_ACCESS_REG));
 
-	wlanSendCommand(prAdapter, prCmdInfo);
+	{
+		uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+		if (rStatus != WLAN_STATUS_SUCCESS &&
+		    rStatus != WLAN_STATUS_PENDING) {
+			DBGLOG(INIT, WARN, "%s: send command failed! status=%u\n",
+			       __func__, rStatus);
+			cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+			kalMemFree(aucBuffer, PHY_MEM_TYPE, u4EventSize);
+			return WLAN_STATUS_FAILURE;
+		}
+	}
 	cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 #else
 	wlanSendSetQueryCmdHelper(
@@ -6533,7 +6555,18 @@ uint32_t wlanQueryNicCapabilityV2(IN struct ADAPTER *prAdapter)
 			NULL, FALSE, 0, S2D_INDEX_CMD_H2N,
 			prCmdInfo->fgNeedResp);
 
-		wlanSendCommand(prAdapter, prCmdInfo);
+		{
+			uint32_t rStatus = wlanSendCommand(prAdapter, prCmdInfo);
+
+			if (rStatus != WLAN_STATUS_SUCCESS &&
+			    rStatus != WLAN_STATUS_PENDING) {
+				DBGLOG(INIT, WARN,
+				       "%s: send command failed! status=%u\n",
+				       __func__, rStatus);
+				cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
+				return WLAN_STATUS_FAILURE;
+			}
+		}
 
 		cmdBufFreeCmdInfo(prAdapter, prCmdInfo);
 

--- a/common/wlan_lib.c
+++ b/common/wlan_lib.c
@@ -4746,6 +4746,10 @@ uint32_t wlanQueryPdMcr(IN struct ADAPTER *prAdapter,
 	u4EventSize = prChipInfo->rxd_size + prChipInfo->event_hdr_size +
 		struct CMD_ACCESS_REG;
 	aucBuffer = kalMemAlloc(u4EventSize, PHY_MEM_TYPE);
+	if (!aucBuffer) {
+		DBGLOG(INIT, ERROR, "Not enough memory for aucBuffer\n");
+		return WLAN_STATUS_FAILURE;
+	}
 
 #ifndef CFG_SUPPORT_UNIFIED_COMMAND
 	/* compose CMD_BUILD_CONNECTION cmd pkt */

--- a/include/nic/mac.h
+++ b/include/nic/mac.h
@@ -2477,7 +2477,7 @@ struct ACTION_NEIGHBOR_REPORT_FRAME {
 struct SUB_ELEMENT {
 	uint8_t ucSubID;
 	uint8_t ucLength;
-	uint8_t aucOptInfo[1];
+	uint8_t aucOptInfo[];  /* C99 flexible array member */
 } __KAL_ATTRIB_PACKED__;
 
 struct SM_BASIC_REQ {

--- a/mgmt/ais_fsm.c
+++ b/mgmt/ais_fsm.c
@@ -6904,7 +6904,7 @@ void aisSendNeighborRequest(struct ADAPTER *prAdapter,
 	uint8_t ucBssIndex)
 {
 	struct SUB_ELEMENT_LIST *prSSIDIE;
-	uint8_t aucBuffer[sizeof(*prSSIDIE) + 31];
+	uint8_t aucBuffer[sizeof(*prSSIDIE) + ELEM_MAX_LEN_SSID];
 	struct BSS_INFO *prBssInfo
 		= aisGetAisBssInfo(prAdapter, ucBssIndex);
 

--- a/mgmt/p2p_func.c
+++ b/mgmt/p2p_func.c
@@ -3767,7 +3767,7 @@ void p2pFuncValidateRxActionFrame(IN struct ADAPTER *prAdapter,
 					prActPubVenFrame->ucPubSubType,
 					&fgBufferFrame);
 		}
-		/* Fall through */
+		fallthrough;
 	default:
 		break;
 	}

--- a/os/linux/gl_kal.c
+++ b/os/linux/gl_kal.c
@@ -6944,6 +6944,7 @@ static void kalProcessCfg80211RxPkt(struct PARAM_CFG80211_REQ *prCfg80211Req)
 #if (KERNEL_VERSION(5, 1, 0) <= CFG80211_VERSION_CODE)
 		/* [TODO] Set uapsd_queues/req_ies/req_ies_len properly */
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	{
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 		struct cfg80211_rx_assoc_resp_data resp = {
 #else
@@ -6958,6 +6959,7 @@ static void kalProcessCfg80211RxPkt(struct PARAM_CFG80211_REQ *prCfg80211Req)
 		resp.req_ies_len = 0;
 		resp.uapsd_queues = 0;
 		cfg80211_rx_assoc_resp(prCfg80211Req->prDevHandler, &resp);
+	}
 #else
 		cfg80211_rx_assoc_resp(prCfg80211Req->prDevHandler,
 			prCfg80211Req->bss,


### PR DESCRIPTION
## Summary

Two stability fixes for the mt7902 driver, improving error handling and fixing compiler warnings.

Depends on #23 (branched from `fix-fortify-source-overflow`).

## Changes

### 1. fix: stability improvements and compiler warning fixes
- Add missing NULL check after `kalMemAlloc()` in `wlanQueryPdMcr()` to prevent NULL pointer dereference under memory pressure
- Use `fallthrough` macro instead of `/* Fall through */` comment in `p2pFuncValidateRxActionFrame()` to fix `-Wimplicit-fallthrough` warning
- Add block scope around variable declaration in `kalProcessCfg80211RxPkt()` to fix `-Wc23-extensions` warning on kernel 6.1+

### 2. fix: check wlanSendCommand return value before waiting for response
Three call sites (`wlanQueryNicCapability`, `wlanQueryPdMcr`, `wlanQueryNicCapabilityV2`) were ignoring the return value of `wlanSendCommand()`. If the send fails, the code proceeds to wait for a response that will never arrive, leading to a timeout or hang. Now checks the return value and bails out with proper resource cleanup on failure.